### PR TITLE
fix quramy/electron-connect#74 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "electron ."
+    "start": "gulp serve"
   },
   "devDependencies": {
     "electron": "1.6.7",
-    "electron-connect": "^0.6.1"
+    "electron-connect": "^0.6.1",
+    "gulp": "^3.9.1"
   }
 }


### PR DESCRIPTION
You weren't starting electron-connect's server, hence 'connection refused' error..

This pull request fixes quramy/electron-connect#74